### PR TITLE
URL change from Koel to TestPro

### DIFF
--- a/src/test/java/LoginTests.java
+++ b/src/test/java/LoginTests.java
@@ -17,7 +17,7 @@ public class LoginTests extends BaseTest {
         WebDriver driver = new ChromeDriver(options);
         driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(10));
 
-        String url = "https://qa.koel.app/";
+        String url = "https://testpro.io/";
         driver.get(url);
         Assert.assertEquals(driver.getCurrentUrl(), url);
         driver.quit();


### PR DESCRIPTION
changed from  "https://qa.koel.app/" to "https://testpro.io/".